### PR TITLE
fix: Remove redundant goroutine

### DIFF
--- a/imrpc/internal/svc/servicecontext.go
+++ b/imrpc/internal/svc/servicecontext.go
@@ -27,7 +27,7 @@ func NewServiceContext(c config.Config) *ServiceContext {
 	// 第一次初始化
 	queueList := GetQueueList(c.QueueEtcd)
 	threading.GoSafe(func() {
-		go discovery.QueueDiscoveryProc(c.QueueEtcd, queueList)
+		discovery.QueueDiscoveryProc(c.QueueEtcd, queueList)
 	})
 	rds, err := redis.NewRedis(redis.RedisConf{
 		Host: c.BizRedis.Host,


### PR DESCRIPTION
1. 修复了 imrpc/internal/svc/servicecontext.go threading.GoSafe下重复创建 goroutine 的问题