### PR TITLE
fix: fix kqconf error

### DIFF
--- a/edge/etc/edge.yaml
+++ b/edge/etc/edge.yaml
@@ -4,11 +4,11 @@ SendChanSize: 1024
 Etcd:
   Hosts:
     - 127.0.0.1:2379
-  Key: "edge_01"  
+  Key: "edge_01"
 KqConf:
   Name: edge_01
   Brokers:
-    - 127.0.1:9092
+    - 127.0.0.1:9092
   Group: group-edge-01
   Topic: topic-edge-01
   Offset: last


### PR DESCRIPTION
1. 修复了 edge/etc/edge.yaml kafka的broker host错误